### PR TITLE
gzdoom: patch to link liboutput_sdl.so against libsdl

### DIFF
--- a/gzdoom/patches/link-liboutput_sdl-against-SDL.patch
+++ b/gzdoom/patches/link-liboutput_sdl-against-SDL.patch
@@ -1,0 +1,10 @@
+--- a/output_sdl/CMakeLists.txt
++++ b/output_sdl/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ cmake_minimum_required( VERSION 2.4 )
+ add_library( output_sdl MODULE output_sdl.c )
+ include_directories( ${FMOD_INCLUDE_DIR} ${SDL_INCLUDE_DIR} )
++target_link_libraries( output_sdl SDL )
+ 
+ FILE( WRITE ${CMAKE_CURRENT_BINARY_DIR}/link-make "if [ ! -e ${ZDOOM_OUTPUT_DIR}/liboutput_sdl.so ]; then ln -sf output_sdl/liboutput_sdl.so ${ZDOOM_OUTPUT_DIR}/liboutput_sdl.so; fi" )
+ add_custom_command( TARGET output_sdl POST_BUILD

--- a/gzdoom/patches/series
+++ b/gzdoom/patches/series
@@ -1,0 +1,2 @@
+link-liboutput_sdl-against-SDL.patch
+link-liboutput_sdl.so-against-SDL.patch

--- a/gzdoom/patches/series
+++ b/gzdoom/patches/series
@@ -1,2 +1,1 @@
 link-liboutput_sdl-against-SDL.patch
-link-liboutput_sdl.so-against-SDL.patch


### PR DESCRIPTION
liboutput_sdl.so uses symbols from SDL.
