### PR TITLE
gzdoom: updates in shell script and rules

### DIFF
--- a/gzdoom/get-fmodex-for-linux.sh
+++ b/gzdoom/get-fmodex-for-linux.sh
@@ -12,6 +12,11 @@ rm -f $changelog
 dirname=fmodapi${version}linux
 fname=${dirname}.tar.gz
 
+if [ $1 = "getrevision" ] ; then
+    echo $pointversion | cut -d. -f3
+    exit 0
+fi
+
 # download fmod ex
 if [ ! -f $fname ] ; then
     wget "http://www.fmod.org/download/fmodex/api/Linux/$fname"

--- a/gzdoom/rules
+++ b/gzdoom/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-fmodrevision = 42
+fmodrevision = $(shell debian/get-fmodex-for-linux.sh getrevision)
 
 ifeq ($(DEB_HOST_ARCH), amd64)
 LIB64 = 64
@@ -14,8 +14,8 @@ fmodlib = libfmodex$(LIB64)-$(fmodpointversion).so
 %:
 	dh $@ --parallel
 
-override_dh_clean:
-	dh_clean
+override_dh_auto_clean:
+	dh_auto_clean
 	rm -rf fmodapi*
 	rm -rf build
 
@@ -24,7 +24,6 @@ override_dh_auto_configure:
 	rm -rf build fmodapi*linux
 	mkdir build
 	tar xvf fmodapi*linux.tar.gz
-	cd $(fmoddirname) && $(MAKE)
 
 	# FMOD ex doesn't have a soname entry. The linker will therefore use
 	# its filename to declare dependencies. Using a different filename allows
@@ -43,7 +42,7 @@ override_dh_auto_configure:
 	-DFMOD_INCLUDE_DIR=$(fmoddirname)/api/inc/ $(CURDIR)
 
 override_dh_auto_build:
-	cd build && $(MAKE)
+	dh_auto_build -Dbuild
 
 override_dh_auto_install:
 	# will be handled by dh_install


### PR DESCRIPTION
Get fmod revision from the shell script.
And there's no point in running `cd $(fmoddirname) && $(MAKE)`.
