### PR TITLE
removed obsolete build dependencies

### DIFF
--- a/netmaumau/control
+++ b/netmaumau/control
@@ -5,19 +5,16 @@ Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
 Build-Depends: cdbs,
                debhelper (>= 9),
                dh-autoreconf,
-               autotools-dev,
-               pkg-config,
-               debconf,
-               libpopt-dev (>= 1.10),
                doxygen (>= 1.8.0),
                graphviz,
-               automake1.11,
                help2man,
-               vim-common,
-               libmagic-dev,
                libgsl0-dev,
+               libmagic-dev,
+               libpopt-dev (>= 1.10),
+               libsqlite3-dev (>= 3.4.2),
                lsb-release,
-               libsqlite3-dev (>= 3.4.2)
+               pkg-config,
+               vim-common
 Standards-Version: 3.9.5
 Homepage: http://sourceforge.net/projects/netmaumau/
 

--- a/netmaumau/rules
+++ b/netmaumau/rules
@@ -11,18 +11,12 @@ DEB_HOST_GNU_TYPE  := $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_GNU_TYPE := $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
-ifeq ($(DEB_BUILD_ARCH),amd64)
-MARCH := -m64 -march=k8 -mtune=generic
-else
-MARCH := -m32 -march=$(DEB_HOST_GNU_CPU) -mtune=generic
-endif
-
 DPKG_EXPORT_BUILDFLAGS = 1
 
 DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_CPPFLAGS_MAINT_APPEND := -DNDEBUG
-DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer $(MARCH)
-DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer $(MARCH)
+DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer
+DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/autotools.mk

--- a/nmm-qt-client/control
+++ b/nmm-qt-client/control
@@ -2,15 +2,13 @@ Source: nmm-qt-client
 Section: games
 Priority: extra
 Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
+
 Build-Depends: cdbs,
                debhelper (>= 9),
-               pkg-config,
+               libespeak-dev,
                libqt4-dev,
-               libqt4-dev-bin,
-               qt4-dev-tools,
-               qt4-linguist-tools,
                netmaumau-dev (>= 0.15~),
-               libespeak-dev
+               pkg-config
 Standards-Version: 3.9.5
 Homepage: http://sourceforge.net/projects/netmaumau/
 
@@ -22,7 +20,7 @@ Depends: libnetmaumaucommon4 (>= 0.15~),
          ${misc:Depends}
 Suggests: netmaumau-server
 Description: Qt client for NetMauMau
- Qt4 client for the NetMauMau server. It offers a complete
+ Qt client for the NetMauMau server. It offers a complete
  playable client for playing against other players or
  AI opponents over the network.
  It can start a local server if installed and supports a

--- a/nmm-qt-client/rules
+++ b/nmm-qt-client/rules
@@ -8,17 +8,9 @@ DEB_HOST_GNU_TYPE  := $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_GNU_TYPE := $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
-ifeq ($(DEB_BUILD_ARCH),amd64)
-MARCH := -m64 -march=k8 -mtune=generic
-else
-MARCH := -m32 -march=$(DEB_HOST_GNU_CPU) -mtune=generic
-endif
-
 DPKG_EXPORT_BUILDFLAGS = 1
 
 DEB_BUILD_MAINT_OPTIONS = hardening=+all
-DEB_CFLAGS_MAINT_APPEND := $(MARCH)
-DEB_CXXFLAGS_MAINT_APPEND := $(MARCH)
 
 DEB_QMAKE_CONFIG_VAL += espeak
 


### PR DESCRIPTION
- with help of  _Gianfranco Costamagna costamagnagianfranco@yahoo.it_ I was able to drill down obsolete build dependencies
- also useless -m32/-m64 options have been removed from _rules_
