### PR TITLE
[nmm-qt-client] updated min Qt version, clean more before build

### DIFF
--- a/nmm-qt-client/control
+++ b/nmm-qt-client/control
@@ -5,7 +5,7 @@ Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
 Build-Depends: cdbs,
                debhelper (>= 9),
                libespeak-dev,
-               libqt4-dev,
+               libqt4-dev (>= 4.4.0),
                netmaumau-dev (>= 0.16~),
                pkg-config
 Standards-Version: 3.9.5

--- a/nmm-qt-client/rules
+++ b/nmm-qt-client/rules
@@ -30,3 +30,4 @@ common-build-arch::
 
 clean::
 	-rm $(CURDIR)/src/*.qm
+	rm -rf $(CURDIR)/release-moc $(CURDIR)/release-rcc


### PR DESCRIPTION
I've backported nmm-qt-client to hardy and the upcoming version 0.17 will be able to compile with Qt >= 4.4.0, so I've just documented that changes in the `debian/control`

Further I experienced that **not** removing the directories `release-moc` and `release-rcc` can cause problems sometimes. Since it is safe to delete the before the build, I do so in the `clean` target.
