### PR TITLE
Vivid: Changes for the upcoming version 0.21(.0)

### DIFF
--- a/netmaumau/control
+++ b/netmaumau/control
@@ -103,7 +103,7 @@ Replaces: libnetmaumauclient0,
           libnetmaumauclient3
 Provides: netmaumau-client-api-15
 Description: Server for the popular card game Mau Mau - client library
- Functions for establisching a connection and playing with a NetMauMau server.
+ Functions for establishing a connection and playing with a NetMauMau server.
 
 Package: netmaumau-dev
 Architecture: any

--- a/netmaumau/control
+++ b/netmaumau/control
@@ -24,14 +24,14 @@ Homepage: http://sourceforge.net/projects/netmaumau/
 Package: netmaumau-client
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumaucommon5 (>= 0.19.1~),
-         libnetmaumauclient4 (>= 0.19.1~),
+Depends: libnetmaumauclient4 (>= 0.20.2~),
+         libnetmaumaucommon5 (>= 0.20.2~),
          ${misc:Depends},
          ${shlibs:Depends}
 Suggests: nmm-qt-client
 Description: Server for the popular card game Mau Mau - console client
  A simple console client for the NetMauMau server.
- It is intended for testing and not for efficient and joyful game play.
+ It is originally intended for testing and not for efficient and joyful game play.
 
 Package: netmaumau-server-common
 Architecture: all
@@ -39,27 +39,48 @@ Recommends: xinetd
 Pre-Depends: dpkg (>= 1.15.6~)
 Depends: ${misc:Depends}
 Description: Server for the popular card game Mau Mau - common server files
- Provides a server for the popular card game NetMauMau. Up to 5 players can 
- play against each other, or against up to 4 tactical AI opponents.
- 
+ Play the popular card game Mau Mau (similar to UNO®) against the computer or over the network
+ with your friends.
+ .
+ Features:
+ .
+  * Play against an unlimited number of tactical playing computer opponents
+  * Play against an unlimited number of human players over the network
+  * Play ace/queen/king rounds (optional)
+  * Support for player images
+  * Server side scores
+  * Away from home, but PC is running? On Linux/BSD you can run the server on demand
+    by using (x)inetd
+  * Highly customizeable rules, even tweak them to your needs with Lua
+
 Package: netmaumau-server
 Architecture: any
 Recommends: xinetd
+Suggests: nmm-qt-client
 Pre-Depends: dpkg (>= 1.15.6~)
 Depends: libnetmaumaucommon5 (>= ${binary:Version}),
          netmaumau-server-common (>= ${source:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Server for the popular card game Mau Mau - server
- Provides a server for the popular card game NetMauMau. Up to 5 players can 
- play against each other, or against up to 4 tactical AI opponents.
-Suggests: nmm-qt-client
+ Play the popular card game Mau Mau (similar to UNO®) against the computer or over the network
+ with your friends.
+ .
+ Features:
+ .
+  * Play against an unlimited number of tactical playing computer opponents
+  * Play against an unlimited number of human players over the network
+  * Play ace/queen/king rounds (optional)
+  * Support for player images
+  * Server side scores
+  * Away from home, but PC is running? On Linux/BSD you can run the server on demand
+    by using (x)inetd
+  * Highly customizeable rules, even tweak them to your needs with Lua
 
 Package: libnetmaumaucommon5
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Suggests: nmm-qt-client
 Description: Server for the popular card game Mau Mau - common library
  Common functions shared between the NetMauMau server and NetMauMau clients.
 Replaces: libnetmaumaucommon0,
@@ -76,13 +97,13 @@ Pre-Depends: dpkg (>= 1.15.6~)
 Depends: libnetmaumaucommon5 (>= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
-Replaces: libnetmaumauclient0, 
-          libnetmaumauclient1, 
+Replaces: libnetmaumauclient0,
+          libnetmaumauclient1,
           libnetmaumauclient2,
           libnetmaumauclient3
 Provides: netmaumau-client-api-15
 Description: Server for the popular card game Mau Mau - client library
- Functions for connecting to a NetMauMau server.
+ Functions for establisching a connection and playing with a NetMauMau server.
 
 Package: netmaumau-dev
 Architecture: any
@@ -105,4 +126,4 @@ Depends: libnetmaumauclient4 (= ${binary:Version}),
          netmaumau-server (= ${binary:Version}),
          ${misc:Depends}
 Description: Server for the popular card game Mau Mau - debugger symbols
- Debugger symbols for the NetMauMau package
+ Debugger symbols for the NetMauMau package.

--- a/netmaumau/netmaumau-server.postinst
+++ b/netmaumau/netmaumau-server.postinst
@@ -17,10 +17,16 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-
 case "$1" in
     configure)
-	chown nobody:nogroup /var/games/netmaumau
+        chown nobody:nogroup /var/games/netmaumau
+
+        if [ -n "`pgrep -f "nmm-server"`" ]; then
+            if [ -n "`pgrep -f "inetd"`" ]; then
+                echo "Stopping nmm-server…"
+				killall nmm-server
+            fi
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/nmm-qt-client/control
+++ b/nmm-qt-client/control
@@ -6,7 +6,7 @@ Build-Depends: cdbs,
                debhelper (>= 9),
                libespeak-dev,
                libqt4-dev (>= 4.4.0),
-               netmaumau-dev (>= 0.19.1~),
+               netmaumau-dev (>= 0.20.2~),
                pkg-config
 Standards-Version: 3.9.5
 Homepage: http://sourceforge.net/projects/netmaumau/
@@ -14,8 +14,8 @@ Homepage: http://sourceforge.net/projects/netmaumau/
 Package: nmm-qt-client
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumauclient4 (>= 0.19.1~),
-         libnetmaumaucommon5 (>= 0.19.1~),
+Depends: libnetmaumauclient4 (>= 0.20.2~),
+         libnetmaumaucommon5 (>= 0.20.2~),
          ${misc:Depends},
          ${shlibs:Depends}
 Suggests: netmaumau-server

--- a/nmm-qt-client/control
+++ b/nmm-qt-client/control
@@ -5,9 +5,11 @@ Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
 Build-Depends: cdbs,
                debhelper (>= 9),
                libespeak-dev,
-               libqt4-dev (>= 4.4.0),
+               libqt5svg5-dev,
                netmaumau-dev (>= 0.20.2~),
                pkg-config
+               qt5-default,
+               qttools5-dev-tools
 Standards-Version: 3.9.5
 Homepage: http://sourceforge.net/projects/netmaumau/
 

--- a/nmm-qt-client/rules
+++ b/nmm-qt-client/rules
@@ -8,9 +8,9 @@ DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 DEB_CPPFLAGS_MAINT_APPEND := -D_GLIBCXX_VISIBILITY=0 -DNDEBUG
-DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
-DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
-DEB_LDFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
+DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
+DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
+DEB_LDFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
 DPKG_EXPORT_BUILDFLAGS=1
 
 include /usr/share/cdbs/1/rules/debhelper.mk
@@ -24,7 +24,7 @@ DH_ALWAYS_EXCLUDE=.svn
 DEB_DH_STRIP_ARGS_DEFAULT = --dbg-package=nmm-qt-client-dbg -n
 
 common-build-arch::
-	/usr/bin/lrelease-qt4 $(CURDIR)/nmm-qt-client.pro
+	/usr/bin/lrelease $(CURDIR)/nmm-qt-client.pro
 
 clean::
 	-rm $(CURDIR)/src/*.qm

--- a/nmm-qt-client/rules
+++ b/nmm-qt-client/rules
@@ -8,9 +8,9 @@ DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 DEB_CPPFLAGS_MAINT_APPEND := -D_GLIBCXX_VISIBILITY=0 -DNDEBUG
-DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
-DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
-DEB_LDFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing -Wl,-fuse-ld=gold
+DEB_CFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
+DEB_CXXFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
+DEB_LDFLAGS_MAINT_APPEND := -fomit-frame-pointer -fstrict-aliasing
 DPKG_EXPORT_BUILDFLAGS=1
 
 include /usr/share/cdbs/1/rules/debhelper.mk

--- a/nmm-qt-client/source/options
+++ b/nmm-qt-client/source/options
@@ -1,3 +1,6 @@
 compression = "xz"
 compression-level = 9
-extend-diff-ignore = release\-moc.*|release\-rcc.*
+extend-diff-ignore = usr|release\-moc.*|release\-rcc.*
+tar-ignore = release-*
+tar-ignore = usr/*
+tar-ignore = *.ico


### PR DESCRIPTION
This release will use Qt5.
Vivid in Kubuntu flavour has switched to KDE5, so I guess using Qt5 matches better. The original source compiles with both Qt4 >= 4.4 and Qt5.
