### PR TITLE
Vivid redeclipse debian sync

### DIFF
--- a/redeclipse-data/changelog
+++ b/redeclipse-data/changelog
@@ -1,3 +1,16 @@
+redeclipse-data (1.5.2+ds1-1~getdeb1) UNRELEASED; urgency=medium
+
+  * Sync with Debian
+
+ -- Martin Erik Werner <martinerikwerner@gmail.com>  Sun, 21 Jun 2015 23:56:19 +0200
+
+redeclipse-data (1.5.2+ds1-1) UNRELEASED; urgency=medium
+
+  * New upstream patch release 1.5 "Aurora Edition" Patch 2
+  * Use uscan to repack tarball via Files-Exluded in debian/copyright
+
+ -- Martin Erik Werner <martinerikwerner@gmail.com>  Fri, 19 Jun 2015 17:14:46 +0200
+
 redeclipse-data (1.5.1-1~getdeb2) trusty; urgency=medium
 
   * Sync with Debian

--- a/redeclipse-data/clean
+++ b/redeclipse-data/clean
@@ -1,1 +1,1 @@
-fonts/*
+fonts/play*

--- a/redeclipse-data/control
+++ b/redeclipse-data/control
@@ -3,11 +3,11 @@ Section: games
 Priority: optional
 Uploaders: Martin Erik Werner <martinerikwerner@gmail.com>
 Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
-Build-Depends: cube2font,
-               debhelper (>= 9),
-               fonts-play
-Standards-Version: 3.9.5
+Build-Depends: cube2font, debhelper (>= 9), fonts-play
+Standards-Version: 3.9.6
 Homepage: http://www.redeclipse.net
+Vcs-Git: git://anonscm.debian.org/pkg-games/redeclipse-data.git
+Vcs-Browser: http://anonscm.debian.org/gitweb/?p=pkg-games/redeclipse-data.git
 
 Package: redeclipse-data
 Architecture: all

--- a/redeclipse-data/copyright
+++ b/redeclipse-data/copyright
@@ -3,6 +3,10 @@ Upstream-Name: Red Eclipse
 Upstream-Contact: Quinton "Quin" Reeves <qreeves@gmail.com>
                   Lee "Eihrul" Salzman <lsalzman@gmail.com>
 Source: https://github.com/red-eclipse/data
+ The Play font files sources are removed since they are shipped in the
+ fonts-play package in Debian, and the generated png files are removed to
+ simplify the build process.
+Files-Excluded: fonts/Play* fonts/play*
 License: Red-Eclipse-Data
  Content included in the game (maps, textures, sounds, models etc.) may have
  individual copyrights and distribution restrictions (see individual readmes),
@@ -180,7 +184,7 @@ License: RaZgRiZ-simple-attribution
 Files: particles/blood.png
        particles/fire.png
 Copyright: FischKopF
-License: public-domain
+License: FischKopF-public-domain
  Created by FischKopF, source: http://www.quadropolis.us/node/2693
  Uploaded explicitly as "Public Domain", with the additional comment:
  "Feel free to edit, claim it's yours, use it in own projects"
@@ -221,6 +225,91 @@ License: CC-BY-SA-3.0
 Files: nobiax/*
 Copyright: Nobiax
 License: CC0-1.0
+
+Files: fonts/akashi*.ttf
+Copyright: 2007-2013 Ten by Twenty
+License: OFL-1.1
+Comment:
+ I, Martin Erik Werner ("arand") have had a longer email discussion with Ed
+ Merrit (the Author of Akashi) regarding the license of the Akashi font
+ available from Ten By Twenty, and the conclusion is that the Akashi font is
+ distibuted under the SIL Open Font License (OFL) 1.1
+ Copyright © 2007 - 2013 Ten by Twenty.
+ .
+ The concluding bits from the email conversation are reproduced below:
+ .
+ Message-ID: <517F948C.8040909@edmerritt.com>
+ Date: Tue, 30 Apr 2013 10:53:16 +0100
+ From: Ed Merritt <ed@edmerritt.com>
+ To: Martin Erik Werner <martinerikwerner@gmail.com>
+ Subject: Re: Fwd: akashi license
+ References: <4EB54D50.30708@gmail.com> <4EB54DF3.30105@edmerritt.com>
+           <1364335792.6577.62.camel@mas> <1367096373.20993.29.camel@mas>
+ In-Reply-To: <1367096373.20993.29.camel@mas>
+ .
+ Hi Martin,
+ I've updated the footer of the site to state that all fonts are
+ distributed under the SIL Open Font License.
+ .
+ Ed
+ .
+ .
+ .
+ On 27/04/2013 21:59, Martin Erik Werner wrote:
+ > Hi,
+ >
+ > I know I'm nagging a bit :) But could you have a look at the questions
+ > in my last email below?
+ >
+ > We'd like to know where to go with our usage of Akashi and things kind
+ > of depend on whether or not we can get a clarification of the license.
+ >
+ > Pretty please? :)
+ .
+ Message-ID: <1364335792.6577.62.camel@mas>
+ Subject: Re: Fwd: akashi license
+ From: Martin Erik Werner <martinerikwerner@gmail.com>
+ To: Ed Merritt <ed@edmerritt.com>
+ Date: Tue, 26 Mar 2013 23:09:52 +0100
+ In-Reply-To: <4EB54DF3.30105@edmerritt.com>
+ References: <4EB54D50.30708@gmail.com> <4EB54DF3.30105@edmerritt.com>
+ .
+ Hi Ed,
+ .
+ (I was using the alias "Arand Nash" with the ienorand@gmail.com email
+ previously. I've since switched over to using the birth name)
+ .
+ We are currently using your typeface "Akashi" for several pieces of
+ "word art" and in the logo of the Free and Open Source FPS game Red
+ Eclipse <http://redeclipse.net>.
+ .
+ It's an awesome font which we really like! :)
+ .
+ I previously contacted you regarding a clarification of the font
+ license, since we tend to be a bit picky with our licenses in order to
+ remain fully open source, the clarification I got at that point we
+ deemed fine.
+ .
+ However, it seems that some distributions, into which we would very much
+ like Red Eclipse to be accepted, wants a more formal license for things
+ (explicitly allowing use, modification, and redistribution with or
+ without modification).
+ .
+ (The discussion in question is on a bug report for the game package in
+ the linux distribution Fedora:
+ https://bugzilla.redhat.com/show_bug.cgi?id=895947)
+ .
+ Would it be possible to get a more formal clarification of the license
+ for the Akashi font covering those bits, or more preferably, would it be
+ possible to use the Akashi font under a well-known license like the
+ OFL-1.1, since this would make sure to avoid all the misinterpretation
+ pitfalls of a custom-written license.
+ .
+ Thanks!
+ --
+ Martin Erik Werner "arand" <martinerikwerner@gmail.com>
+ .
+ <removed previous quoted email conversation>
 
 Files: textures/logo.png luckystrike/pub2* luckystrike/pub1*
 Copyright: Ed Merrit, Ten by Twenty, <http://www.tenbytwenty.com/>
@@ -412,6 +501,94 @@ License: Expat
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  DEALINGS IN THE SOFTWARE.
+
+License: OFL-1.1
+ -----------------------------------------------------------
+ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+ -----------------------------------------------------------
+ .
+ PREAMBLE
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font creation
+ efforts of academic and linguistic communities, and to provide a free and
+ open framework in which fonts may be shared and improved in partnership
+ with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply
+ to any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components as
+ distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to, deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software to a
+ new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical
+ writer or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components,
+ in Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or
+ in the appropriate machine-readable metadata fields within text or
+ binary files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the corresponding
+ Copyright Holder. This restriction only applies to the primary font name as
+ presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole,
+ must be distributed entirely under this license, and must not be
+ distributed under any other license. The requirement for fonts to
+ remain under this license does not apply to any document created
+ using the Font Software.
+ .
+ TERMINATION
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.
 
 License: CC-BY-3.0
  THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE

--- a/redeclipse-data/generate-copyright
+++ b/redeclipse-data/generate-copyright
@@ -23,6 +23,10 @@ Upstream-Name: Red Eclipse
 Upstream-Contact: Quinton "Quin" Reeves <qreeves@gmail.com>
                   Lee "Eihrul" Salzman <lsalzman@gmail.com>
 Source: https://github.com/red-eclipse/data
+ The Play font files sources are removed since they are shipped in the
+ fonts-play package in Debian, and the generated png files are removed to
+ simplify the build process.
+Files-Excluded: fonts/Play* fonts/play*
 License: Red-Eclipse-Data
 EOF
 
@@ -33,15 +37,16 @@ sed -e 's/^/\ /' -e 's/^\ $/\ \./' readme.txt >> debian/copyright-new
 sed '/Format:.*/d' "$all_licenses"  >> debian/copyright-new
 
 # Remove all records related to bin/*, config/*, doc/*, data/fonts/* and src/*
-awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^Files: (bin|config|doc|data\/fonts|src)\// ' debian/copyright-new > debian/copyright-temp
+# (not present in the source)
+awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^Files: (bin|config|doc|src)\// ' debian/copyright-new > debian/copyright-temp
+mv debian/copyright-temp debian/copyright-new
+
+# Remove records for Play font files (deleted from source package)
+awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^Files: data\/fonts\/[Pp]lay/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
 # Remove data/ prefix
 sed 's/ data\// /g' debian/copyright-new > debian/copyright-temp
-mv debian/copyright-temp debian/copyright-new
-
-# Remove record for "OFL-1.1" license
-awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: OFL-1.1$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
 # Add marker for inserting Debian chunk

--- a/redeclipse-data/rules
+++ b/redeclipse-data/rules
@@ -21,16 +21,5 @@ override_dh_auto_install:
 override_dh_builddeb:
 	dh_builddeb -- -Zxz
 
-DIR=redeclipse-data-$(DEB_VERSION_UPSTREAM).orig
 get-orig-source:
-	uscan --noconf --rename --force-download --download-current-version \
-		--destdir=.
-	rm -rf $(DIR)
-	tar -xf redeclipse-data_$(DEB_VERSION_UPSTREAM).orig.tar.gz
-	rm -f redeclipse-data_$(DEB_VERSION_UPSTREAM).orig.tar.gz
-	mv data-$(DEB_VERSION_UPSTREAM)/ $(DIR)
-	rm -rf $(DIR)/fonts
-	find $(DIR) -type f -name '.git*' -delete
-	XZ_OPT="-6" tar --create --xz --owner root --group root --mode a+rX \
-		-f redeclipse-data_$(DEB_VERSION_UPSTREAM).orig.tar.xz $(DIR)
-	rm -rf $(DIR)
+	uscan --noconf --rename --repack --compression xz --force-download --download-current-version --destdir=.

--- a/redeclipse-data/source/lintian-overrides
+++ b/redeclipse-data/source/lintian-overrides
@@ -1,7 +1,7 @@
 # The license is CC-BY-SA-3.0+, meaning "or later", albeit valid, is not a
 # recognised license shortname.
 # The stand-alone license paragraph has the standard CC-BY-SA-3.0 version.
-missing-license-paragraph-in-dep5-copyright cc-by-sa-3.0+ (paragraph at line 230)
+missing-license-paragraph-in-dep5-copyright cc-by-sa-3.0+ (paragraph at line 319)
 # A summary license field in the header should be allowed according to the
 # specification, probable false positive, see #769818.
-missing-license-paragraph-in-dep5-copyright red-eclipse-data (paragraph at line 25)
+dep5-file-paragraph-reference-header-paragraph red-eclipse-data (paragraph at line 29)

--- a/redeclipse-data/watch
+++ b/redeclipse-data/watch
@@ -1,3 +1,4 @@
 version=3
-opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/redeclipse-data-$1\.tar\.gz/ \
+opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/redeclipse-data-$1\.tar\.gz/,\
+dversionmangle=s/\+ds\d*$// \
   https://github.com/red-eclipse/data/tags .*/v?(\d\S*)\.tar\.gz

--- a/redeclipse/changelog
+++ b/redeclipse/changelog
@@ -1,3 +1,24 @@
+redeclipse (1.5.2-1~getdeb1) UNRELEASED; urgency=medium
+
+  * Sync with Debian
+
+ -- Martin Erik Werner <martinerikwerner@gmail.com>  Sun, 21 Jun 2015 23:15:19 +0200
+
+redeclipse (1.5.2+ds1-1) UNRELEASED; urgency=medium
+
+  * New upstream patch release 1.5 "Aurora Edition" Patch 2
+  * Use uscan to repack tarball via Files-Exluded in debian/copyright
+  * Drop backported patches which are now in new release
+    - Delete appdata-Fill-in-remove-FIXMEs.patch
+    - Delete appdata-Update-description-screenshots.patch
+    - Delete appdata-Upgrade-via-appstream-util.patch
+    - Delete appdate-Use-template-set-at-install-name.patch
+    - Delete system-install-Add-common-install-target-for-common-.patch
+    - Delete system-install-Add-doc-link-for-client-finding-guide.patch
+    - Delete system-install-Install-appdata.patch
+
+ -- Martin Erik Werner <martinerikwerner@gmail.com>  Wed, 22 Apr 2015 21:42:31 +0200
+
 redeclipse (1.5.1-1~getdeb3~vivid) vivid; urgency=medium
 
   * Sync with Debian

--- a/redeclipse/control
+++ b/redeclipse/control
@@ -14,6 +14,8 @@ Build-Depends: debhelper (>= 9),
                zlib1g-dev | libz-dev
 Standards-Version: 3.9.6
 Homepage: http://www.redeclipse.net
+Vcs-Git: git://anonscm.debian.org/pkg-games/redeclipse.git
+Vcs-Browser: http://anonscm.debian.org/gitweb/?p=pkg-games/redeclipse.git
 
 Package: redeclipse
 Architecture: any

--- a/redeclipse/copyright
+++ b/redeclipse/copyright
@@ -3,9 +3,15 @@ Upstream-Name: Red Eclipse
 Upstream-Contact: Quinton "Quin" Reeves <qreeves@gmail.com>
                   Lee "Eihrul" Salzman <lsalzman@gmail.com>
 Source: https://github.com/red-eclipse/base
- The folders src/include/ src/xcode/ src/lib/ bin/ are removed, the header
- files here are already shipped within other Debian packages, or are
- unnecessary on GNU/Linux.
+ The following directories/files are removed from the upstream tarball:
+ * bin contains various binaries and helper libs not relevant for Debian,
+   auto-update scripts are kept (though not used in Debian)
+ * data is instead shipped as redeclipse-data in Debian
+ * src/enet is instead shipped as libenet in Debian
+ * src/include contains duplicate headers already in other Debian packages
+ * src/lib contains prebuilt duplicate libs already in other Debian packages
+Files-Excluded: bin/amd64 bin/redeclipse.app bin/tools bin/x86  data
+                src/enet src/include src/lib
 License: Red-Eclipse
  THE RED ECLIPSE LICENSE
  .
@@ -540,3 +546,4 @@ License: Mark-Policy
  If you currently have a product that is using the Red Eclipse marks in a way
  that don't follow this policy, don't panic. Let us know, and we'll work it out,
  as described above.
+

--- a/redeclipse/generate-copyright
+++ b/redeclipse/generate-copyright
@@ -9,9 +9,15 @@ Upstream-Name: Red Eclipse
 Upstream-Contact: Quinton "Quin" Reeves <qreeves@gmail.com>
                   Lee "Eihrul" Salzman <lsalzman@gmail.com>
 Source: https://github.com/red-eclipse/base
- The folders src/include/ src/xcode/ src/lib/ bin/ are removed, the header
- files here are already shipped within other Debian packages, or are
- unnecessary on GNU/Linux.
+ The following directories/files are removed from the upstream tarball:
+ * bin contains various binaries and helper libs not relevant for Debian,
+   auto-update scripts are kept (though not used in Debian)
+ * data is instead shipped as redeclipse-data in Debian
+ * src/enet is instead shipped as libenet in Debian
+ * src/include contains duplicate headers already in other Debian packages
+ * src/lib contains prebuilt duplicate libs already in other Debian packages
+Files-Excluded: bin/amd64 bin/redeclipse.app bin/tools bin/x86  data
+                src/enet src/include src/lib
 License: Red-Eclipse
 EOF
 
@@ -29,23 +35,27 @@ mv debian/copyright-temp debian/copyright-new
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^Files: data\//' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
-# Remove record for "OFL-1.1" license
+# Remove record for "OFL-1.1" license (data/* content)
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: OFL-1.1$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
-# Remove record for "CC-BY-3.0" license
+# Remove record for "CC-BY-3.0" license (data/* content)
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: CC-BY-3.0$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
-# Remove record for "CC-BY-SA-3.0-US" license
+# Remove record for "CC-BY-SA-3.0-US" license (data/* content)
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: CC-BY-3.0-US$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
-# Remove record for "CC-BY-SA-3.0-AU" license
+# Remove record for "CC-BY-SA-3.0-AU" license (data/* content)
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: CC-BY-SA-3.0-AU$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
-# Remove record for "Expat" license
+# Remove record for "CC0-1.0" license (data/* content)
+awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: CC0-1.0$/' debian/copyright-new > debian/copyright-temp
+mv debian/copyright-temp debian/copyright-new
+
+# Remove record for "Expat" license (src/enet/* content)
 awk 'BEGIN{ ORS="\n\n"; RS="" ; FS="\n"} $1 !~ /^License: Expat$/' debian/copyright-new > debian/copyright-temp
 mv debian/copyright-temp debian/copyright-new
 
@@ -62,3 +72,5 @@ License: Zlib
 .
 w
 EOF
+
+echo "done -> debian/copyright-new"

--- a/redeclipse/patches/series
+++ b/redeclipse/patches/series
@@ -1,8 +1,1 @@
 windowed-by-default.patch
-system-install-Add-common-install-target-for-common-.patch
-appdate-Use-template-set-at-install-name.patch
-appdata-Upgrade-via-appstream-util.patch
-appdata-Fill-in-remove-FIXMEs.patch
-appdata-Update-description-screenshots.patch
-system-install-Install-appdata.patch
-system-install-Add-doc-link-for-client-finding-guide.patch

--- a/redeclipse/redeclipse-common.doc-base
+++ b/redeclipse/redeclipse-common.doc-base
@@ -1,0 +1,8 @@
+Document: redeclipse-common
+Title: Red Eclipse Common Information
+Author: Red Eclipse Team
+Abstract: General common information for Red Eclipse
+Section: Games/Action
+
+Format: Text
+Files: /usr/share/games/redeclipse/doc/guidelines.txt

--- a/redeclipse/redeclipse-common.install
+++ b/redeclipse/redeclipse-common.install
@@ -1,2 +1,4 @@
 usr/lib/games/redeclipse/config
+usr/share/doc/redeclipse/guidelines.txt
 usr/share/games/redeclipse/config
+usr/share/games/redeclipse/doc

--- a/redeclipse/redeclipse.doc-base
+++ b/redeclipse/redeclipse.doc-base
@@ -6,4 +6,3 @@ Section: Games/Action
 
 Format: Text
 Files: /usr/share/doc/redeclipse/readme.txt.gz
-       /usr/share/doc/redeclipse/guidelines.txt

--- a/redeclipse/redeclipse.install
+++ b/redeclipse/redeclipse.install
@@ -3,6 +3,5 @@ usr/lib/games/redeclipse/doc
 usr/lib/games/redeclipse/redeclipse
 usr/share/appdata
 usr/share/applications
-usr/share/doc/redeclipse/guidelines.txt
 usr/share/icons
 usr/share/pixmaps

--- a/redeclipse/rules
+++ b/redeclipse/rules
@@ -47,22 +47,5 @@ override_dh_compress:
 override_dh_builddeb:
 	dh_builddeb -- -Zxz
 
-DIR=redeclipse-$(DEB_VERSION_UPSTREAM).orig
 get-orig-source:
-	uscan --noconf --rename --force-download --download-current-version --destdir=.
-	rm -rf $(DIR)
-	tar -xf redeclipse_$(DEB_VERSION_UPSTREAM).orig.tar.gz
-	rm -f redeclipse_$(DEB_VERSION_UPSTREAM).orig.tar.gz
-	mv base-$(DEB_VERSION_UPSTREAM)/ $(DIR)
-	rm -rf $(DIR)/src/include/
-	rm -rf $(DIR)/src/enet/
-	rm -rf $(DIR)/src/xcode/
-	rm -rf $(DIR)/src/lib/
-	rm -rf $(DIR)/src/install/win/
-	rm -rf $(DIR)/bin/
-	rm -rf $(DIR)/data/
-	rm -f $(DIR)/*.bat
-	find $(DIR) -type f -iname '.git*' -delete
-	XZ_OPT="-6" tar --create --xz --owner root --group root --mode a+rX \
-		-f redeclipse_$(DEB_VERSION_UPSTREAM).orig.tar.xz $(DIR)
-	rm -rf $(DIR)
+	uscan --noconf --rename --repack --compression xz --force-download --download-current-version --destdir=.

--- a/redeclipse/source/lintian-overrides
+++ b/redeclipse/source/lintian-overrides
@@ -1,8 +1,8 @@
 # The license is CC-BY-SA-3.0+, meaning "or later", albeit valid, is not a
 # recognised license shortname.
 # The stand-alone license paragraph has the standard CC-BY-SA-3.0 version.
-missing-license-paragraph-in-dep5-copyright cc-by-sa-3.0+ (paragraph at line 73)
+missing-license-paragraph-in-dep5-copyright cc-by-sa-3.0+ (paragraph at line 79)
 # A summary license field in the header should be allowed according to the
 # specification, probable false positive, see #769818.
-missing-license-paragraph-in-dep5-copyright red-eclipse (paragraph at line 57)
+dep5-file-paragraph-reference-header-paragraph red-eclipse (paragraph at line 63)
 

--- a/redeclipse/watch
+++ b/redeclipse/watch
@@ -1,3 +1,4 @@
 version=3
-opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/redeclipse-$1\.tar\.gz/ \
+opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/redeclipse-$1\.tar\.gz/,\
+dversionmangle=s/\+ds\d*$// \
   https://github.com/red-eclipse/base/tags .*/v?(\d\S*)\.tar\.gz


### PR DESCRIPTION
The following changes since commit b03608c376c36446fc1ff23a9d3aef1c420a00d0:

  openra: 20150614-1~getdeb1 (2015-06-17 23:26:02 +0200)

are available in the git repository at:

  https://github.com/ienorand/PlayDeb.git vivid-redeclipse-debian-sync

for you to fetch changes up to fe309ea73932ab7c68423c57720507f0c2b82a27:

  redeclipse-data: Sync with Debian (2015-06-21 23:59:38 +0200)

---

Martin Erik Werner (2):
      redeclipse: Sync with Debian
      redeclipse-data: Sync with Debian

 redeclipse-data/changelog                |  13 +++
 redeclipse-data/clean                    |   2 +-
 redeclipse-data/control                  |   8 +-
 redeclipse-data/copyright                | 179 ++++++++++++++++++++++++++++++-
 redeclipse-data/generate-copyright       |  15 ++-
 redeclipse-data/rules                    |  13 +--
 redeclipse-data/source/lintian-overrides |   4 +-
 redeclipse-data/watch                    |   3 +-
 redeclipse/changelog                     |  21 ++++
 redeclipse/control                       |   2 +
 redeclipse/copyright                     |  13 ++-
 redeclipse/generate-copyright            |  28 +++--
 redeclipse/patches/series                |   7 --
 redeclipse/redeclipse-common.doc-base    |   8 ++
 redeclipse/redeclipse-common.install     |   2 +
 redeclipse/redeclipse.doc-base           |   1 -
 redeclipse/redeclipse.install            |   1 -
 redeclipse/rules                         |  19 +---
 redeclipse/source/lintian-overrides      |   4 +-
 redeclipse/watch                         |   3 +-
 20 files changed, 279 insertions(+), 67 deletions(-)
 create mode 100644 redeclipse/redeclipse-common.doc-base
