### PR TITLE
NetMauMau 0.24.0 and nmm-qt-client rebuild

### DIFF
--- a/netmaumau/control
+++ b/netmaumau/control
@@ -2,30 +2,33 @@ Source: netmaumau
 Section: games
 Priority: extra
 Maintainer: GetDeb Package Ninjas <package.ninjas@getdeb.net>
-Build-Depends: cdbs,
+Build-Depends: bash-completion,
                binutils-gold,
                cdbs,
                debhelper (>= 9),
                dh-autoreconf,
                doxygen (>= 1.8.0),
+               gawk,
                graphviz,
                help2man,
                libgsl0-dev,
                liblua5.1-0-dev (>= 5.1.2),
                libmagic-dev,
+               libmicrohttpd-dev,
                libpopt-dev (>= 1.10),
                libsqlite3-dev (>= 3.4.2),
                lsb-release,
                pkg-config,
-               vim-common
+               vim-common,
+               zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: http://sourceforge.net/projects/netmaumau/
 
 Package: netmaumau-client
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumauclient4 (>= 0.20.2~),
-         libnetmaumaucommon5 (>= 0.20.2~),
+Depends: libnetmaumauclient5 (>= 0.23.5~),
+         libnetmaumaucommon6 (>= 0.23.4~),
          ${misc:Depends},
          ${shlibs:Depends}
 Suggests: nmm-qt-client
@@ -58,7 +61,7 @@ Architecture: any
 Recommends: xinetd
 Suggests: nmm-qt-client
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumaucommon5 (>= ${binary:Version}),
+Depends: libnetmaumaucommon6 (>= ${binary:Version}),
          netmaumau-server-common (>= ${source:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
@@ -77,7 +80,7 @@ Description: Server for the popular card game Mau Mau - server
     by using (x)inetd
   * Highly customizeable rules, even tweak them to your needs with Lua
 
-Package: libnetmaumaucommon5
+Package: libnetmaumaucommon6
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
 Depends: ${misc:Depends}, ${shlibs:Depends}
@@ -87,20 +90,22 @@ Replaces: libnetmaumaucommon0,
           libnetmaumaucommon1,
           libnetmaumaucommon2,
           libnetmaumaucommon3,
-          libnetmaumaucommon4
+          libnetmaumaucommon4,
+		  libnetmaumaucommon5
 Section: libs
 
-Package: libnetmaumauclient4
+Package: libnetmaumauclient5
 Architecture: any
 Section: libs
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumaucommon5 (>= ${binary:Version}),
+Depends: libnetmaumaucommon6 (>= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: libnetmaumauclient0,
           libnetmaumauclient1,
           libnetmaumauclient2,
-          libnetmaumauclient3
+          libnetmaumauclient3,
+		  libnetmaumauclient4
 Provides: netmaumau-client-api-15
 Description: Server for the popular card game Mau Mau - client library
  Functions for establishing a connection and playing with a NetMauMau server.
@@ -108,8 +113,8 @@ Description: Server for the popular card game Mau Mau - client library
 Package: netmaumau-dev
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumauclient4 (= ${binary:Version}),
-         libnetmaumaucommon5 (= ${binary:Version}),
+Depends: libnetmaumauclient5 (= ${binary:Version}),
+         libnetmaumaucommon6 (= ${binary:Version}),
          ${misc:Depends}
 Suggests: netmaumau-server
 Description: Server for the popular card game Mau Mau - developer files
@@ -120,8 +125,8 @@ Package: netmaumau-dbg
 Architecture: any
 Section: debug
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumauclient4 (= ${binary:Version}),
-         libnetmaumaucommon5 (= ${binary:Version}),
+Depends: libnetmaumauclient5 (= ${binary:Version}),
+         libnetmaumaucommon6 (= ${binary:Version}),
          netmaumau-client (= ${binary:Version}),
          netmaumau-server (= ${binary:Version}),
          ${misc:Depends}

--- a/netmaumau/libnetmaumauclient4.install
+++ b/netmaumau/libnetmaumauclient4.install
@@ -1,2 +1,0 @@
-/usr/lib/libnetmaumauclient.so.4
-/usr/lib/libnetmaumauclient.so.4.*

--- a/netmaumau/libnetmaumauclient5.install
+++ b/netmaumau/libnetmaumauclient5.install
@@ -1,0 +1,1 @@
+/usr/lib/libnetmaumauclient.so.*

--- a/netmaumau/libnetmaumauclient5.shlibs
+++ b/netmaumau/libnetmaumauclient5.shlibs
@@ -1,0 +1,1 @@
+libnetmaumauclient 5 libnetmaumauclient5 (>= 0.23.7~)

--- a/netmaumau/libnetmaumaucommon5.install
+++ b/netmaumau/libnetmaumaucommon5.install
@@ -1,2 +1,0 @@
-/usr/lib/libnetmaumaucommon.so.5
-/usr/lib/libnetmaumaucommon.so.5.*

--- a/netmaumau/libnetmaumaucommon6.install
+++ b/netmaumau/libnetmaumaucommon6.install
@@ -1,0 +1,1 @@
+/usr/lib/libnetmaumaucommon.so.*

--- a/netmaumau/libnetmaumaucommon6.shlibs
+++ b/netmaumau/libnetmaumaucommon6.shlibs
@@ -1,0 +1,1 @@
+libnetmaumaucommon 6 libnetmaumaucommon6 (>= 0.23.7~)

--- a/netmaumau/netmaumau-dev.install
+++ b/netmaumau/netmaumau-dev.install
@@ -1,5 +1,4 @@
 /usr/include/netmaumau
-/usr/lib/lib*.a
 /usr/lib/pkgconfig
 /usr/lib/libnetmaumaucommon.so
 /usr/lib/libnetmaumauclient.so

--- a/netmaumau/netmaumau-server-common.install
+++ b/netmaumau/netmaumau-server-common.install
@@ -1,4 +1,5 @@
 /etc/xinetd.d/netmaumau
+/usr/share/netmaumau/*.ico
 /usr/share/netmaumau/*.PNG
 /usr/share/netmaumau/*.lua
 /usr/share/bash-completion/completions/nmm-server

--- a/netmaumau/rules
+++ b/netmaumau/rules
@@ -32,7 +32,7 @@ include /usr/share/cdbs/1/rules/autoreconf.mk
 -include /usr/share/dpkg/buildflags.mk
 
 DEB_CONFIGURE_EXTRA_FLAGS = --bindir=\$${prefix}/games --enable-console-client \
-	--enable-ai-image=/usr/share/pixmaps/debian-logo.png \
+	--disable-static --enable-ai-image=/usr/share/pixmaps/debian-logo.png \
 	--enable-ai-name="`lsb_release -sc | sed 's/.*/\u&/'`" --localstatedir=/var/games \
 	--with-bashcompletiondir="\$${datarootdir}/bash-completion/completions"
 DEB_MAKE_CHECK_TARGET = check

--- a/netmaumau/source/options
+++ b/netmaumau/source/options
@@ -4,7 +4,6 @@ tar-ignore = .svn
 tar-ignore = .git
 tar-ignore = .gitignore
 tar-ignore = V*.xml
-tar-ignore = netmaumau.ico
 tar-ignore = "DIE\ OFFIZIELLEN\ MAUMAU\ SPIELREGELN.pdf"
 tar-ignore = *.patch
 tar-ignore = config.log

--- a/nmm-qt-client/control
+++ b/nmm-qt-client/control
@@ -7,7 +7,7 @@ Build-Depends: cdbs,
                libespeak-dev,
                libmarkdown2-dev,
                libqt5svg5-dev,
-               netmaumau-dev (>= 0.22.0~),
+               netmaumau-dev (>= 0.23.7~),
                pkg-config,
                qtbase5-dev,
                qttools5-dev-tools
@@ -17,9 +17,7 @@ Homepage: http://sourceforge.net/projects/netmaumau/
 Package: nmm-qt-client
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6~)
-Depends: libnetmaumauclient4 (>= 0.21.1~),
-         libnetmaumaucommon5 (>= 0.21.1~),
-         ${misc:Depends},
+Depends: ${misc:Depends},
          ${shlibs:Depends}
 Suggests: netmaumau-server
 Description: Qt client for NetMauMau


### PR DESCRIPTION
Should fix https://github.com/velnias75/NetMauMau/issues/38 

Actually the error is caused, because pbuilder installs `mawk` instead of `gawk` by default, thus I included it into the build deps.

The rebuild of `nmm-qt-client` is neccessary because of the SONAME bump of the `netmaumau` libs.
The new libs are _fully_ source compatible.
