### PR TITLE
No need to ./configure OpenRA

### DIFF
--- a/openra/rules
+++ b/openra/rules
@@ -6,7 +6,6 @@ override_dh_auto_configure:
 	mozroots --import --sync
 	cd thirdparty && ./fetch-thirdparty-deps.sh
 	make dependencies
-	dh_auto_configure
 
 override_dh_auto_test:
 	cp thirdparty/download/* .


### PR DESCRIPTION
We removed our `configure` script as everyone confused it with the ones autotools provides and fed it with parameters which were all ignored so `make dependencies` will now take care about everything. https://github.com/OpenRA/OpenRA/pull/8082 Also if nuget is causing trouble (I see the mozroots workaround there) we are also providing a fallback now. https://github.com/OpenRA/OpenRA/pull/8229
