### PR TITLE
CorsixTH: Change link to GitHub

### DIFF
--- a/corsix-th/control
+++ b/corsix-th/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 9),
                libswscale-dev,
                libpostproc-dev
 Standards-Version: 3.9.5
-Homepage: https://code.google.com/p/corsix-th/
+Homepage: https://github.com/CorsixTH/CorsixTH/
 
 Package: corsix-th
 Architecture: any


### PR DESCRIPTION
It's been a while since they moved to GitHub, and the homepage link hasn't been updated to use the GitHub link. It still uses the old Google Code link
